### PR TITLE
Bump golang to 1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17 as builder
+FROM golang:1.18 as builder
 
 USER root
 


### PR DESCRIPTION
It appears `strings.Cut` is not available in golang 1.17. Bumping it to 1.18 fixes this build error:

```
 => [stage-1  2/11] RUN apt-get update -y     && apt-get upgrade -y     && apt-get install supervisor -y     && apt-get clean cache     && rm -rf /var/lib/apt                                          10.2s
 => [builder 2/7] RUN apt-get update -y     && apt-get install build-essential curl git -y                                                                                                               4.2s
 => [builder 3/7] WORKDIR /go                                                                                                                                                                            0.0s 
 => ERROR [builder 4/7] RUN git clone https://github.com/grafana/loki.git     && cd loki     && make loki logcli                                                                                        46.2s 
------                                                                                                                                                                                                        
 > [builder 4/7] RUN git clone https://github.com/grafana/loki.git     && cd loki     && make loki logcli:                                                                                                    
#10 0.323 Cloning into 'loki'...                                                                                                                                                                              
Updating files: 100% (10735/10735), done.5)                                                                                                                                                                   
#10 9.922 CGO_ENABLED=0 go build -ldflags "-extldflags \"-static\" -s -w -X github.com/grafana/loki/pkg/util/build.Branch=main -X github.com/grafana/loki/pkg/util/build.Version=main-1f7fabf -X github.com/grafana/loki/pkg/util/build.Revision=1f7fabfbb -X github.com/grafana/loki/pkg/util/build.BuildUser=root@buildkitsandbox -X github.com/grafana/loki/pkg/util/build.BuildDate=2022-11-13T17:55:10Z" -tags netgo -o cmd/loki/loki ./cmd/loki                                                                                                                                                                                     
#10 23.88 # github.com/grafana/regexp/syntax                                                                                                                                                                  
#10 23.88 vendor/github.com/grafana/regexp/syntax/parse.go:1037:18: undefined: strings.Cut                                                                                                                    
#10 46.04 make: *** [Makefile:138: cmd/loki/loki] Error 2                                                                                                                                                     
------
Error failed to fetch an image or build from source: error building: executor failed running [/bin/sh -c git clone https://github.com/grafana/loki.git     && cd loki     && make loki logcli]: exit code: 2
```